### PR TITLE
Double quotes, escaped characters and saving to json

### DIFF
--- a/tasks/mustache.js
+++ b/tasks/mustache.js
@@ -72,8 +72,7 @@ module.exports = function(grunt) {
 
       }
 
-      // replace any tabs and linebreaks and double spaces
-      _templateOutput += "    " + templateContent.replace( /\r|\n|\t|\s\s/g, '') + "\n";
+      _templateOutput += templateContent;
 
       if(grunt.file.isFile(file)){
 
@@ -112,9 +111,11 @@ module.exports = function(grunt) {
 
       templateCount++;
       var escapeDoubleQuotes = grunt.file.read(abspath).replace(/"/g, '\\"');
-      var fileContent = escapeDoubleQuotes.replace(/\\\\/g, '\\'); // escape escaped characters
+      var escapeEscapedCharacters = escapeDoubleQuotes.replace(/\\\\/g, '\\');
+      var fileContent =  escapeEscapedCharacters.replace( /\r|\n|\t|\s\s/g, ''); // Removes line breaks and double spaces
 
-      templateContent += '"' + filename.split('.mustache')[0] + '"' + ' : "' + fileContent + '",'+"\n";
+
+      templateContent += '    "' + filename.split('.mustache')[0] + '"' + ' : "' + fileContent + '",' + "\n";
 
       if(grunt.option('verbose')){
 

--- a/tasks/mustache.js
+++ b/tasks/mustache.js
@@ -111,7 +111,7 @@ module.exports = function(grunt) {
     if(abspath.split('.').pop() === 'mustache'){
 
       templateCount++;
-      templateContent += '"' + filename.split('.mustache')[0] + '"' + ' : \'' + grunt.file.read(abspath) + '\','+"\n";
+      templateContent += '"' + filename.split('.mustache')[0] + '"' + ' : "' + grunt.file.read(abspath) + '",'+"\n";
 
       if(grunt.option('verbose')){
 

--- a/tasks/mustache.js
+++ b/tasks/mustache.js
@@ -111,7 +111,10 @@ module.exports = function(grunt) {
     if(abspath.split('.').pop() === 'mustache'){
 
       templateCount++;
-      templateContent += '"' + filename.split('.mustache')[0] + '"' + ' : "' + grunt.file.read(abspath) + '",'+"\n";
+      var escapeDoubleQuotes = grunt.file.read(abspath).replace(/"/g, '\\"');
+      var fileContent = escapeDoubleQuotes.replace(/\\\\/g, '\\'); // escape escaped characters
+
+      templateContent += '"' + filename.split('.mustache')[0] + '"' + ' : "' + fileContent + '",'+"\n";
 
       if(grunt.option('verbose')){
 


### PR DESCRIPTION
I have added three things:
- escaping double quotes - this is helpful when people have used double quotes in a template
- escaping escaped characters - in case they have already escaped the double quotes
- template content surrounded by double quotes - this way, it can be saved directly to json in the Gruntfile

I've tested it all one of my projects and it works as it should!
